### PR TITLE
fix: tls versions cannot be combined in a single rule

### DIFF
--- a/aws_network_firewall/rule.py
+++ b/aws_network_firewall/rule.py
@@ -44,7 +44,9 @@ class Rule:
         options = [
             SuricataOption(name="tls.sni"),
             SuricataOption(name="tls.version", value="1.2", quoted_value=False),
-            SuricataOption(name="tls.version", value="1.3", quoted_value=False),
+            # When using multiple tls versions you need 2 rules
+            # openssl 1.1.1 is needed for tls1.3
+            # SuricataOption(name="tls.version", value="1.3", quoted_value=False),
         ]
 
         if endpoint.startswith("*"):

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -23,7 +23,7 @@ def test_rule_with_tls_endpoint() -> None:
     )
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; tls.version: 1.2; tls.version: 1.3; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; tls.version: 1.2; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
         == str(rule)
     )
 
@@ -48,7 +48,7 @@ def test_rule_with_tls_wildcard_endpoint() -> None:
     )
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; tls.version: 1.2; tls.version: 1.3; dotprefix; content: ".xebia.com"; nocase; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; tls.version: 1.2; dotprefix; content: ".xebia.com"; nocase; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
         == str(rule)
     )
 
@@ -73,7 +73,7 @@ def test_rule_with_tls_endpoint_non_standard_port() -> None:
     )
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; tls.version: 1.2; tls.version: 1.3; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)\n'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; tls.version: 1.2; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)\n'
         + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (msg: "my-workload | my-rule | Pass non-established TCP for 3-way handshake"; flow: "not_established"; rev: 1; sid: XXX;)'
         == str(rule)
     )
@@ -149,6 +149,6 @@ def test_egress_tls_rule() -> None:
     )
 
     assert (
-        'pass tls  any -> any 443 (tls.sni; tls.version: 1.2; tls.version: 1.3; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
+        'pass tls  any -> any 443 (tls.sni; tls.version: 1.2; content: "xebia.com"; nocase; startswith; endswith; msg: "my-workload | my-rule"; rev: 1; sid: XXX;)'
         == str(rule)
     )

--- a/tests/workloads/example-workload/README.md
+++ b/tests/workloads/example-workload/README.md
@@ -50,7 +50,7 @@ xebia.com | 192.168.8.0/21 | eu-central-1 | TLS  | 443 | My destination
 Based on the above defined sources and destination the following firewall rules are required:
 
 ```
-pass tls 192.168.0.0/21 any -> 192.168.8.0/21 443 (tls.sni; tls.version: 1.2; tls.version: 1.3; content: "xebia.com"; nocase; startswith; endswith; msg: "binxio-example-workload-development | My Rule name"; rev: 1; sid: XXX;)
+pass tls 192.168.0.0/21 any -> 192.168.8.0/21 443 (tls.sni; tls.version: 1.2; content: "xebia.com"; nocase; startswith; endswith; msg: "binxio-example-workload-development | My Rule name"; rev: 1; sid: XXX;)
 
 ```
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

You cannot combine 2 tbs version requirements in a single rule.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
