### PR TITLE
feat: display rules per region

### DIFF
--- a/aws_network_firewall/account.py
+++ b/aws_network_firewall/account.py
@@ -1,12 +1,17 @@
 from __future__ import annotations
-from typing import List, Optional
+
+import itertools
+from typing import List, Union
 from landingzone_organization import Account as LandingZoneAccount
 from aws_network_firewall.cidr_ranges import CidrRanges
+from aws_network_firewall.destination import Destination
 from aws_network_firewall.rule import Rule
+from aws_network_firewall.rule_set import RuleSet
+from aws_network_firewall.source import Source
 
 
 class Account(LandingZoneAccount):
-    __rules: List[Rule]
+    __rules: RuleSet
     __cidr_ranges: CidrRanges
 
     def __init__(
@@ -14,34 +19,36 @@ class Account(LandingZoneAccount):
     ) -> None:
         super().__init__(name, account_id)
         self.__cidr_ranges = cidr_ranges
-        self.__rules = list(map(self.__enrich_rule, rules))
+        self.__rules = RuleSet(rules=list(map(self.__enrich_rule, rules)))
 
     def __enrich_rule(self, rule: Rule) -> Rule:
-        list(
-            map(
-                lambda source: source.resolve_region_cidr_ranges(self.__cidr_ranges),
-                rule.sources,
-            )
-        )
-        list(
-            map(
-                lambda destination: destination.resolve_region_cidr_ranges(
-                    self.__cidr_ranges
-                ),
-                rule.destinations,
-            )
-        )
+        cidr_range = self.__cidr_ranges.by_region(rule.region)
+
+        def update_cidr_if_not_set(entry: Source) -> None:
+            if cidr_range and not entry.cidr:
+                entry.cidr = cidr_range.value
+
+        list(map(update_cidr_if_not_set, rule.sources))
 
         return rule
 
     @property
-    def rules(self) -> List[Rule]:
+    def regions(self) -> List[str]:
+        return list(set(filter(None, map(lambda rule: rule.region, self.rules.all))))
+
+    def rules_by_region(self, region: str) -> RuleSet:
+        return RuleSet(
+            rules=list(filter(lambda rule: region == rule.region, self.rules.all))
+        )
+
+    @property
+    def rules(self) -> RuleSet:
         return self.__rules
 
     @property
     def inspection_rules(self) -> List[Rule]:
-        return list(filter(lambda rule: rule.is_inspection_rule, self.rules))
+        return list(filter(lambda rule: rule.is_inspection_rule, self.rules.all))
 
     @property
     def egress_rules(self) -> List[Rule]:
-        return list(filter(lambda rule: rule.is_egress_rule, self.rules))
+        return list(filter(lambda rule: rule.is_egress_rule, self.rules.all))

--- a/aws_network_firewall/destination.py
+++ b/aws_network_firewall/destination.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from aws_network_firewall.cidr_ranges import CidrRanges
-
 
 @dataclass
 class Destination:
@@ -15,11 +13,5 @@ class Destination:
     protocol: str
     port: Optional[int]
     endpoint: Optional[str]
-    region: Optional[str]
     cidr: Optional[str]
     message: Optional[str]
-
-    def resolve_region_cidr_ranges(self, ranges: CidrRanges) -> None:
-        if self.region and not self.cidr:
-            cidr = ranges.by_region(self.region)
-            self.cidr = cidr.value if cidr else None

--- a/aws_network_firewall/rule.py
+++ b/aws_network_firewall/rule.py
@@ -17,6 +17,7 @@ class Rule:
     workload: str
     name: str
     type: str
+    region: str
     description: str
     sources: List[Source]
     destinations: List[Destination]

--- a/aws_network_firewall/rule_set.py
+++ b/aws_network_firewall/rule_set.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from typing import List
+
+from aws_network_firewall.rule import Rule
+
+
+class RuleSet:
+    __rules: List[Rule]
+
+    def __init__(self, rules: List[Rule]) -> None:
+        self.__rules = rules
+
+    def __len__(self) -> int:
+        return len(self.all)
+
+    def __iter__(self):
+        for value in self.all:
+            yield value
+
+    @property
+    def all(self) -> List[Rule]:
+        return self.__rules
+
+    @property
+    def inspection_rules(self) -> List[Rule]:
+        return list(filter(lambda rule: rule.is_inspection_rule, self.all))
+
+    @property
+    def egress_rules(self) -> List[Rule]:
+        return list(filter(lambda rule: rule.is_egress_rule, self.all))

--- a/aws_network_firewall/schemas/__init__.py
+++ b/aws_network_firewall/schemas/__init__.py
@@ -16,7 +16,6 @@ def source_resolver(entry: dict) -> Source:
     return Source(
         description=entry["Description"],
         cidr=entry.get("Cidr"),
-        region=entry.get("Region"),
     )
 
 
@@ -26,7 +25,6 @@ def destination_resolver(entry: dict) -> Destination:
         protocol=entry["Protocol"],
         port=entry.get("Port"),
         endpoint=entry.get("Endpoint"),
-        region=entry.get("Region"),
         cidr=entry.get("Cidr"),
         message=entry.get("Message"),
     )
@@ -36,6 +34,7 @@ def rule_resolver(workload: str, entry: dict) -> Rule:
     return Rule(
         workload=workload,
         type=entry["Type"],
+        region=entry["Region"],
         name=entry["Name"],
         description=entry["Description"],
         sources=list(map(source_resolver, entry["Sources"])),

--- a/aws_network_firewall/schemas/environment.yaml
+++ b/aws_network_firewall/schemas/environment.yaml
@@ -49,6 +49,7 @@ definitions:
     required:
       - Name
       - Type
+      - Region
       - Description
       - Sources
       - Destinations
@@ -58,6 +59,8 @@ definitions:
       Type:
         enum: [ "Egress", "Inspection" ]
       Description:
+        type: string
+      Region:
         type: string
       Sources:
         type: array
@@ -78,8 +81,6 @@ definitions:
         type: string
       Cidr:
         type: string
-      Region:
-        type: string
     examples:
       - Description: Allow access from `10.0.0.0/8` to the defined destinations.
         Cidr: 10.0.0.0/8
@@ -93,12 +94,11 @@ definitions:
       - Description
       - Protocol
     anyOf:
+      - required: ["Endpoint", "Cidr"]
       - required: ["Endpoint"]
-        not: { required: ["Region", "Cidr"] }
+        not: { required: ["Cidr"] }
       - required: ["Cidr"]
-        not: { required: ["Endpoint", "Region"] }
-      - required: ["Region"]
-        not: { required: ["Endpoint", "Cidr"] }
+        not: { required: ["Endpoint"] }
 #      Port is not required when Protocol is ICMP
     properties:
       Description:

--- a/aws_network_firewall/source.py
+++ b/aws_network_firewall/source.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Optional
 
-from aws_network_firewall.cidr_ranges import CidrRanges
-
 
 @dataclass
 class Source:
@@ -13,9 +11,3 @@ class Source:
 
     description: str
     cidr: Optional[str]
-    region: Optional[str]
-
-    def resolve_region_cidr_ranges(self, ranges: CidrRanges) -> None:
-        if self.region and not self.cidr:
-            cidr = ranges.by_region(self.region)
-            self.cidr = cidr.value if cidr else None

--- a/tests/test_destination.py
+++ b/tests/test_destination.py
@@ -1,33 +1,4 @@
-from aws_network_firewall.cidr_ranges import CidrRanges
 from aws_network_firewall.destination import Destination
-
-
-def test_destination_region_to_cidr(cidr_ranges: CidrRanges) -> None:
-    destination = Destination(
-        description="",
-        protocol="TLS",
-        port=443,
-        region="eu-west-1",
-        endpoint=None,
-        cidr=None,
-        message=None,
-    )
-    destination.resolve_region_cidr_ranges(cidr_ranges)
-    assert destination.cidr == "10.0.0.0/24"
-
-
-def test_destination_cidr(cidr_ranges: CidrRanges) -> None:
-    destination = Destination(
-        description="",
-        protocol="TLS",
-        port=443,
-        region=None,
-        endpoint=None,
-        cidr="10.0.0.0/24",
-        message=None,
-    )
-    destination.resolve_region_cidr_ranges(cidr_ranges)
-    assert destination.cidr == "10.0.0.0/24"
 
 
 def test_destination_properties() -> None:
@@ -35,7 +6,6 @@ def test_destination_properties() -> None:
         description="My Description",
         protocol="TLS",
         port=443,
-        region="eu-west-1",
         endpoint="xebia.com",
         cidr="10.0.0.0/24",
         message="Important Message",
@@ -43,7 +13,6 @@ def test_destination_properties() -> None:
     assert destination.description == "My Description"
     assert destination.protocol == "TLS"
     assert destination.port == 443
-    assert destination.region == "eu-west-1"
     assert destination.endpoint == "xebia.com"
     assert destination.cidr == "10.0.0.0/24"
     assert destination.message == "Important Message"

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -7,9 +7,10 @@ def test_rule_with_tls_endpoint() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.INSPECTION,
         description="My description",
-        sources=[Source(description="my source", cidr="10.0.0.0/24", region=None)],
+        sources=[Source(description="my source", cidr="10.0.0.0/24")],
         destinations=[
             Destination(
                 description="my destination",
@@ -17,7 +18,6 @@ def test_rule_with_tls_endpoint() -> None:
                 port=443,
                 endpoint="xebia.com",
                 cidr="10.0.1.0/24",
-                region=None,
                 message=None,
             )
         ],
@@ -33,9 +33,10 @@ def test_rule_with_tls_wildcard_endpoint() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.INSPECTION,
         description="My description",
-        sources=[Source(description="my source", cidr="10.0.0.0/24", region=None)],
+        sources=[Source(description="my source", cidr="10.0.0.0/24")],
         destinations=[
             Destination(
                 description="my destination",
@@ -43,7 +44,6 @@ def test_rule_with_tls_wildcard_endpoint() -> None:
                 port=443,
                 endpoint="*.xebia.com",
                 cidr="10.0.1.0/24",
-                region=None,
                 message=None,
             )
         ],
@@ -59,9 +59,10 @@ def test_rule_with_tls_endpoint_non_standard_port() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.INSPECTION,
         description="My description",
-        sources=[Source(description="my source", cidr="10.0.0.0/24", region=None)],
+        sources=[Source(description="my source", cidr="10.0.0.0/24")],
         destinations=[
             Destination(
                 description="my destination",
@@ -69,7 +70,6 @@ def test_rule_with_tls_endpoint_non_standard_port() -> None:
                 port=444,
                 endpoint="xebia.com",
                 cidr="10.0.1.0/24",
-                region=None,
                 message=None,
             )
         ],
@@ -86,9 +86,10 @@ def test_rule_with_tcp_cidr() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.INSPECTION,
         description="My description",
-        sources=[Source(description="my source", cidr="10.0.0.0/24", region=None)],
+        sources=[Source(description="my source", cidr="10.0.0.0/24")],
         destinations=[
             Destination(
                 description="my destination",
@@ -96,7 +97,6 @@ def test_rule_with_tcp_cidr() -> None:
                 port=443,
                 cidr="10.0.1.0/24",
                 endpoint=None,
-                region=None,
                 message=None,
             )
         ],
@@ -112,9 +112,10 @@ def test_icmp_rule() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.INSPECTION,
         description="My description",
-        sources=[Source(description="my source", cidr="10.0.0.0/24", region=None)],
+        sources=[Source(description="my source", cidr="10.0.0.0/24")],
         destinations=[
             Destination(
                 description="my destination",
@@ -122,7 +123,6 @@ def test_icmp_rule() -> None:
                 port=None,
                 cidr="10.0.1.0/24",
                 endpoint=None,
-                region=None,
                 message=None,
             )
         ],
@@ -138,9 +138,10 @@ def test_egress_tls_rule() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.EGRESS,
         description="My description",
-        sources=[Source(description="my source", cidr=None, region="eu-west-1")],
+        sources=[Source(description="my source", cidr=None)],
         destinations=[
             Destination(
                 description="my destination",
@@ -148,7 +149,6 @@ def test_egress_tls_rule() -> None:
                 port=443,
                 cidr=None,
                 endpoint="xebia.com",
-                region=None,
                 message=None,
             )
         ],
@@ -164,9 +164,10 @@ def test_egress_tls_rule_with_message() -> None:
     rule = Rule(
         workload="my-workload",
         name="my-rule",
+        region="eu-west-1",
         type=Rule.EGRESS,
         description="My description",
-        sources=[Source(description="my source", cidr=None, region="eu-west-1")],
+        sources=[Source(description="my source", cidr=None)],
         destinations=[
             Destination(
                 description="my destination",
@@ -174,7 +175,6 @@ def test_egress_tls_rule_with_message() -> None:
                 port=443,
                 cidr=None,
                 endpoint="xebia.com",
-                region=None,
                 message="IMPORTANT BECAUSE ...",
             )
         ],

--- a/tests/test_source.py
+++ b/tests/test_source.py
@@ -1,22 +1,10 @@
-from aws_network_firewall.cidr_ranges import CidrRanges
 from aws_network_firewall.source import Source
 
 
-def test_source_region_to_cidr(cidr_ranges: CidrRanges) -> None:
+def test_source_properties() -> None:
     source = Source(
-        description="",
-        region="eu-west-1",
-        cidr=None,
-    )
-    source.resolve_region_cidr_ranges(cidr_ranges)
-    assert source.cidr == "10.0.0.0/24"
-
-
-def test_source_cidr(cidr_ranges: CidrRanges) -> None:
-    source = Source(
-        description="",
-        region=None,
+        description="My Description",
         cidr="10.0.0.0/24",
     )
-    source.resolve_region_cidr_ranges(cidr_ranges)
+    assert source.description == "My Description"
     assert source.cidr == "10.0.0.0/24"

--- a/tests/workload-firewall-rules.jinja
+++ b/tests/workload-firewall-rules.jinja
@@ -32,16 +32,16 @@ The {{ account.name }} has the following suppressions registered:
 
 #### Sources
 
-**CIDR** | **Region** | **Description**
----------|------------|----------------
-{% for source in rule.sources %}{{ source.cidr }} | {{ source.region }} | {{ source.description }}
+**CIDR** | **Description**
+---------|----------------
+{% for source in rule.sources %}{{ source.cidr }} | {{ source.description }}
 {% endfor %}
 
 #### Destinations
 
-**Endpoint** | **CIDR** | **Region** | **Protocol** | **Port** | **Description**
--------------|----------|------------|--------------|----------|-----------------
-{% for destination in rule.destinations %}{{ destination.endpoint }} | {{ destination.cidr }} | {{ destination.region }} | {{ destination.protocol }}  | {{ destination.port }} | {% autoescape false %}{{ destination.description | replace("\n", "<br/>") }}{% endautoescape %}
+**Endpoint** | **CIDR** | **Protocol** | **Port** | **Description**
+-------------|----------|--------------|----------|-----------------
+{% for destination in rule.destinations %}{{ destination.endpoint }} | {{ destination.cidr }} | {{ destination.protocol }}  | {{ destination.port }} | {% autoescape false %}{{ destination.description | replace("\n", "<br/>") }}{% endautoescape %}
 {% endfor %}
 
 #### Rules

--- a/tests/workloads/example-workload/README.md
+++ b/tests/workloads/example-workload/README.md
@@ -33,16 +33,16 @@ My rule destination
 
 #### Sources
 
-**CIDR** | **Region** | **Description**
----------|------------|----------------
-192.168.0.0/21 | eu-west-1 | My Source
+**CIDR** | **Description**
+---------|----------------
+192.168.0.0/21 | My Source
 
 
 #### Destinations
 
-**Endpoint** | **CIDR** | **Region** | **Protocol** | **Port** | **Description**
--------------|----------|------------|--------------|----------|-----------------
-xebia.com | 192.168.8.0/21 | eu-central-1 | TLS  | 443 | My destination
+**Endpoint** | **CIDR** | **Protocol** | **Port** | **Description**
+-------------|----------|--------------|----------|-----------------
+xebia.com | None | TLS  | 443 | My destination
 
 
 #### Rules
@@ -50,7 +50,7 @@ xebia.com | 192.168.8.0/21 | eu-central-1 | TLS  | 443 | My destination
 Based on the above defined sources and destination the following firewall rules are required:
 
 ```
-pass tls 192.168.0.0/21 any -> 192.168.8.0/21 443 (tls.sni; tls.version:1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"binxio-example-workload-development | My Rule name"; rev:1; sid:XXX;)
+pass tls 192.168.0.0/21 any -> any 443 (tls.sni; tls.version:1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"binxio-example-workload-development | My Rule name"; rev:1; sid:XXX;)
 
 ```
 

--- a/tests/workloads/example-workload/development.yaml
+++ b/tests/workloads/example-workload/development.yaml
@@ -6,13 +6,12 @@ CidrRanges:
 Rules:
   - Name: My Rule name
     Type: Egress
+    Region: eu-west-1
     Description: My rule destination
     Sources:
       - Description: My Source
-        Region: eu-west-1
     Destinations:
       - Description: My destination
         Endpoint: xebia.com
-        Region: eu-central-1
         Protocol: TLS
         Port: 443


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

By adding the ability to list rules per region, we make it possible to render documentation per region. This is useful when you have a firewall per region.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
