### PR TITLE
feat: generate rules for dns servers

### DIFF
--- a/aws_network_firewall/schemas/environment.yaml
+++ b/aws_network_firewall/schemas/environment.yaml
@@ -110,7 +110,7 @@ definitions:
       Region:
         type: string
       Protocol:
-        enum: [ "TCP", "TLS", "ICMP" ]
+        enum: [ "TCP", "TLS", "ICMP", "DNS" ]
       Port:
         type: integer
       Message:

--- a/aws_network_firewall/suricata/rule.py
+++ b/aws_network_firewall/suricata/rule.py
@@ -19,22 +19,18 @@ class Rule:
     destination: Host
     options: List[Option]
 
+    __bidirectional: bool = False
+
     def __post_init__(self):
         self.protocol = self.protocol.lower()
+        self.__bidirectional = True if self.protocol == "icmp" else False
+
+    def enable_bidirectional_communication(self) -> None:
+        self.__bidirectional = True
 
     @property
     def direction(self) -> str:
-        message = next(
-            filter(lambda option: option.name == "msg", self.options),
-            Option(name="msg"),
-        )
-        if (
-            "Pass non-established TCP for 3-way handshake" in str(message.value)
-            or self.protocol == "icmp"
-        ):
-            return "<>"
-
-        return "->"
+        return "<>" if self.__bidirectional else "->"
 
     @property
     def source(self) -> str:

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -384,3 +384,31 @@ def test_egress_tls_rule_with_message() -> None:
         'pass tls  any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT BECAUSE ... | my-workload | my-rule"; sid:XXX; rev:1;)'
         == str(rule)
     )
+
+
+def test_dns_rule() -> None:
+    rule = Rule(
+        workload="my-workload",
+        name="my-rule",
+        region="eu-west-1",
+        type=Rule.INSPECTION,
+        description="My description",
+        sources=[Source(description="my source", cidr="10.0.0.10/32")],
+        destinations=[
+            Destination(
+                description="my destination",
+                protocol="DNS",
+                port=None,
+                cidr="192.168.0.10/32",
+                endpoint="",
+                message="",
+                tls_versions=[],
+            )
+        ],
+    )
+
+    assert (
+        'pass tcp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n' +
+        'pass udp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        == str(rule)
+    )

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -408,7 +408,7 @@ def test_dns_rule() -> None:
     )
 
     assert (
-        'pass tcp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n' +
-        'pass udp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tcp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
+        + 'pass udp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
         == str(rule)
     )


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

In some cases you might want to sync Route53 resolvers with on-premise. For this you need to have 2 rules a TCP and a UDP rule and it needs to be bidirectional. For this reason I implemented it on the protocol level. I also made a simpler implementation for controlling when something should be bidirectional.


**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
