### PR TITLE
feat: calculate the used sid per type and region

### DIFF
--- a/aws_network_firewall/account.py
+++ b/aws_network_firewall/account.py
@@ -1,27 +1,35 @@
 from __future__ import annotations
 
-import itertools
-from typing import List, Union
+from typing import List, Dict
 from landingzone_organization import Account as LandingZoneAccount
 from aws_network_firewall.cidr_ranges import CidrRanges
-from aws_network_firewall.destination import Destination
 from aws_network_firewall.rule import Rule
 from aws_network_firewall.rule_set import RuleSet
+from aws_network_firewall.sid_state import SidState
 from aws_network_firewall.source import Source
 
 
 class Account(LandingZoneAccount):
     __rules: RuleSet
     __cidr_ranges: CidrRanges
+    __sid_state: SidState
 
     def __init__(
-        self, name: str, account_id: str, cidr_ranges: CidrRanges, rules: List[Rule]
+        self,
+        name: str,
+        account_id: str,
+        cidr_ranges: CidrRanges,
+        sid_range: str,
+        rules: List[Rule],
     ) -> None:
         super().__init__(name, account_id)
+
         self.__cidr_ranges = cidr_ranges
+        self.__sid_state = SidState(sid_range=sid_range)
         self.__rules = RuleSet(rules=list(map(self.__enrich_rule, rules)))
 
     def __enrich_rule(self, rule: Rule) -> Rule:
+        rule.register_sid_state(self.__sid_state)
         cidr_range = self.__cidr_ranges.by_region(rule.region)
 
         def update_cidr_if_not_set(entry: Source) -> None:

--- a/aws_network_firewall/engines/abstract.py
+++ b/aws_network_firewall/engines/abstract.py
@@ -1,37 +1,49 @@
-from typing import List
+from typing import List, Any, Optional
 from abc import (
     ABC,
     abstractmethod,
 )
 
 from aws_network_firewall.destination import Destination
+from aws_network_firewall.sid_state import SidState
 from aws_network_firewall.suricata import SuricataRule, SuricataOption
 from aws_network_firewall.suricata.host import Host
 
 
 class EngineAbstract(ABC):
-    def __init__(self, sources: List[Host], name: str, workload: str) -> None:
-        self.__sources = sources
-        self.__name = name
-        self.__workload = workload
+    __options: Optional[List[SuricataOption]]
+
+    def __init__(self, rule: Any, sid_state: Optional[SidState]) -> None:
+        self.__rule = rule
+        self.__sid_state = sid_state
 
     @property
     def suricata_source(self) -> List[Host]:
-        return self.__sources
+        return self.__rule.suricata_source
 
     @abstractmethod
     def parse(self, destination: Destination) -> List[SuricataRule]:
         raise NotImplementedError
 
+    def resolve_sid(self) -> int:
+        if not self.__sid_state:
+            return 0
+
+        return self.__sid_state.allocate_sid(
+            rule_type=self.__rule.type, region=self.__rule.region
+        )
+
     def resolve_options(self, destination: Destination) -> List[SuricataOption]:
         message = (
-            f"{destination.message} | {self.__workload} | {self.__name}"
+            f"{destination.message} | {self.__rule.workload} | {self.__rule.name}"
             if destination.message
-            else f"{self.__workload} | {self.__name}"
+            else f"{self.__rule.workload} | {self.__rule.name}"
         )
 
         return [
             SuricataOption(name="msg", value=message),
-            SuricataOption(name="sid", value="XXX", quoted_value=False),
+            SuricataOption(
+                name="sid", value=str(self.resolve_sid()), quoted_value=False
+            ),
             SuricataOption(name="rev", value="1", quoted_value=False),
         ]

--- a/aws_network_firewall/engines/default_rule.py
+++ b/aws_network_firewall/engines/default_rule.py
@@ -3,7 +3,6 @@ from typing import List
 from aws_network_firewall.destination import Destination
 from aws_network_firewall.engines.abstract import EngineAbstract
 from aws_network_firewall.suricata import SuricataRule, SuricataHost
-from aws_network_firewall.suricata.host import Host
 
 
 class DefaultRule(EngineAbstract):

--- a/aws_network_firewall/schemas/__init__.py
+++ b/aws_network_firewall/schemas/__init__.py
@@ -63,5 +63,6 @@ def environment_resolver(path: str) -> Account:
         name=data["Name"],
         account_id=data["AccountId"],
         cidr_ranges=cidr_ranges_resolver(data.get("CidrRanges", {})),
+        sid_range=data.get("SidRange", ""),
         rules=list(map(internal_resolver, data.get("Rules", []))),
     )

--- a/aws_network_firewall/schemas/environment.yaml
+++ b/aws_network_firewall/schemas/environment.yaml
@@ -29,6 +29,9 @@ properties:
         type: string
       us-east-2:
         type: string
+  SidRange:
+    type: string
+    pattern: "^[0-9]+-[0-9]+$"
   Rules:
     type: array
     items:

--- a/aws_network_firewall/sid_state.py
+++ b/aws_network_firewall/sid_state.py
@@ -1,0 +1,36 @@
+from typing import Dict
+
+
+class SidState:
+    __state: Dict[str, Dict[str, int]]
+
+    def __init__(self, sid_range: str) -> None:
+        self.__state = {}
+        self.__min = 0
+        self.__max = 0
+
+        if sid_range:
+            minimum, maximum = sid_range.split("-")
+            self.__min = int(minimum)
+            self.__max = int(maximum)
+
+    def __resolve_next_value(self, rule_type: str, region: str):
+        has_type = self.__state.get(rule_type)
+
+        if not has_type:
+            self.__state[rule_type] = {}
+
+        has_region = self.__state.get(rule_type, {}).get(region)
+
+        if not has_region:
+            self.__state[rule_type][region] = self.__min
+        else:
+            self.__state[rule_type][region] += 1
+
+        return self.__state[rule_type][region]
+
+    def allocate_sid(self, rule_type: str, region: str) -> int:
+        if not self.__min:
+            return 0
+
+        return self.__resolve_next_value(rule_type=rule_type, region=region)

--- a/aws_network_firewall/suricata/rule.py
+++ b/aws_network_firewall/suricata/rule.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List
 
 from aws_network_firewall.suricata.host import Host
 from aws_network_firewall.suricata.option import Option

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -15,6 +15,7 @@ def generate_account(rules: List[Rule]) -> Account:
         cidr_ranges=CidrRanges(
             cidr_ranges=[CidrRange(region="eu-west-1", value="10.0.0.0/8")]
         ),
+        sid_range="",
         rules=rules,
     )
 
@@ -68,6 +69,7 @@ def test_inspection_rules() -> None:
         cidr_ranges=CidrRanges(
             cidr_ranges=[CidrRange(region="eu-west-1", value="10.0.0.0/8")]
         ),
+        sid_range="",
         rules=rules,
     )
     assert len(account.rules) == 1

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -1,5 +1,6 @@
 from aws_network_firewall.destination import Destination
 from aws_network_firewall.rule import Rule
+from aws_network_firewall.sid_state import SidState
 from aws_network_firewall.source import Source
 
 
@@ -23,9 +24,10 @@ def test_rule_with_tls_endpoint() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("100-105"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)'
         == str(rule)
     )
 
@@ -50,9 +52,10 @@ def test_rule_with_tls_1_2_endpoint() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)'
         == str(rule)
     )
 
@@ -77,9 +80,10 @@ def test_rule_with_tls_1_3_endpoint() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("100-105"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)'
         == str(rule)
     )
 
@@ -104,9 +108,10 @@ def test_rule_with_tls_1_2_and_1_3_endpoint() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("100-105"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.2,tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; ssl_version:tls1.2,tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)'
         == str(rule)
     )
 
@@ -131,9 +136,10 @@ def test_rule_with_tls_wildcard_endpoint() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("100-105"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; dotprefix; content:".xebia.com"; nocase; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 443 (tls.sni; dotprefix; content:".xebia.com"; nocase; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)'
         == str(rule)
     )
 
@@ -158,10 +164,11 @@ def test_rule_with_tls_endpoint_non_standard_port() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("100-105"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)\n'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:101; rev:1;)'
         == str(rule)
     )
 
@@ -186,10 +193,11 @@ def test_rule_with_tls_endpoint_non_standard_port_and_message() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT | my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"IMPORTANT | Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT | my-workload | my-rule"; sid:200; rev:1;)\n'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"IMPORTANT | Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -214,10 +222,10 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_2_version() -> None:
             )
         ],
     )
-
+    rule.register_sid_state(SidState("200-205"))
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -242,10 +250,11 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_3_version() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -271,9 +280,11 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_2_and_1_3_version() 
         ],
     )
 
+    rule.register_sid_state(SidState("200-205"))
+
     assert (
-        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2,tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2,tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -298,9 +309,10 @@ def test_rule_with_tcp_cidr() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tcp 10.0.0.0/24 any -> 10.0.1.0/24 443 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tcp 10.0.0.0/24 any -> 10.0.1.0/24 443 (msg:"my-workload | my-rule"; sid:200; rev:1;)'
         == str(rule)
     )
 
@@ -325,9 +337,10 @@ def test_icmp_rule() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass icmp 10.0.0.0/24 any <> 10.0.1.0/24 any (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass icmp 10.0.0.0/24 any <> 10.0.1.0/24 any (msg:"my-workload | my-rule"; sid:200; rev:1;)'
         == str(rule)
     )
 
@@ -352,9 +365,10 @@ def test_egress_tls_rule() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tls  any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls  any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)'
         == str(rule)
     )
 
@@ -379,9 +393,10 @@ def test_egress_tls_rule_with_message() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tls  any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT BECAUSE ... | my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tls  any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT BECAUSE ... | my-workload | my-rule"; sid:200; rev:1;)'
         == str(rule)
     )
 
@@ -406,10 +421,11 @@ def test_dns_rule() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tcp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)\n'
-        + 'pass udp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tcp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
+        + 'pass udp 10.0.0.10/32 any <> 192.168.0.10/32 53 (msg:"my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -434,8 +450,36 @@ def test_prefix_list_rule() -> None:
             )
         ],
     )
+    rule.register_sid_state(SidState("200-205"))
 
     assert (
-        'pass tcp 10.0.0.10/32 any -> @S3PrefixList 443 (msg:"my-workload | my-rule"; sid:XXX; rev:1;)'
+        'pass tcp 10.0.0.10/32 any -> @S3PrefixList 443 (msg:"my-workload | my-rule"; sid:200; rev:1;)'
+        == str(rule)
+    )
+
+
+def test_no_sid_state() -> None:
+    rule = Rule(
+        workload="my-workload",
+        name="my-rule",
+        region="eu-west-1",
+        type=Rule.EGRESS,
+        description="My description",
+        sources=[Source(description="my source", cidr="10.0.0.10/32")],
+        destinations=[
+            Destination(
+                description="my destination",
+                protocol="TCP",
+                port=443,
+                cidr=None,
+                endpoint="@S3PrefixList",
+                message="",
+                tls_versions=[],
+            )
+        ],
+    )
+
+    assert (
+        'pass tcp 10.0.0.10/32 any -> @S3PrefixList 443 (msg:"my-workload | my-rule"; sid:0; rev:1;)'
         == str(rule)
     )

--- a/tests/test_sid_state.py
+++ b/tests/test_sid_state.py
@@ -1,0 +1,35 @@
+from aws_network_firewall.sid_state import SidState
+
+
+def test_state_100_200() -> None:
+    state = SidState("100-200")
+
+    assert state.allocate_sid("Egress", "eu-west-1") == 100
+    assert state.allocate_sid("Egress", "eu-west-1") == 101
+    assert state.allocate_sid("Egress", "eu-west-1") == 102
+    assert state.allocate_sid("Egress", "eu-central-1") == 100
+    assert state.allocate_sid("Egress", "eu-central-1") == 101
+    assert state.allocate_sid("Egress", "eu-central-1") == 102
+    assert state.allocate_sid("Inspection", "eu-west-1") == 100
+    assert state.allocate_sid("Inspection", "eu-west-1") == 101
+    assert state.allocate_sid("Inspection", "eu-west-1") == 102
+    assert state.allocate_sid("Inspection", "eu-central-1") == 100
+    assert state.allocate_sid("Inspection", "eu-central-1") == 101
+    assert state.allocate_sid("Inspection", "eu-central-1") == 102
+
+
+def test_state_500_600() -> None:
+    state = SidState("500-600")
+
+    assert state.allocate_sid("Egress", "eu-west-1") == 500
+    assert state.allocate_sid("Egress", "eu-west-1") == 501
+    assert state.allocate_sid("Egress", "eu-west-1") == 502
+    assert state.allocate_sid("Egress", "eu-central-1") == 500
+    assert state.allocate_sid("Egress", "eu-central-1") == 501
+    assert state.allocate_sid("Egress", "eu-central-1") == 502
+    assert state.allocate_sid("Inspection", "eu-west-1") == 500
+    assert state.allocate_sid("Inspection", "eu-west-1") == 501
+    assert state.allocate_sid("Inspection", "eu-west-1") == 502
+    assert state.allocate_sid("Inspection", "eu-central-1") == 500
+    assert state.allocate_sid("Inspection", "eu-central-1") == 501
+    assert state.allocate_sid("Inspection", "eu-central-1") == 502

--- a/tests/test_workload.py
+++ b/tests/test_workload.py
@@ -1,0 +1,2 @@
+# def test_workload(workload: Workload) -> None:
+#     pass

--- a/tests/workloads/example-workload/README.md
+++ b/tests/workloads/example-workload/README.md
@@ -50,7 +50,7 @@ xebia.com | None | TLS  | 443 | My destination
 Based on the above defined sources and destination the following firewall rules are required:
 
 ```
-pass tls 192.168.0.0/21 any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"binxio-example-workload-development | My Rule name"; sid:XXX; rev:1;)
+pass tls 192.168.0.0/21 any -> any 443 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"binxio-example-workload-development | My Rule name"; sid:0; rev:1;)
 
 ```
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

When you use firewall groups per type and region you can re-use sid numbers. By allocating a range per account we prevent overlap.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
