### PR TITLE
fix: tls rules without endpoints

### DIFF
--- a/aws_network_firewall/engines/tls_rule.py
+++ b/aws_network_firewall/engines/tls_rule.py
@@ -52,20 +52,21 @@ class TlsRule(EngineAbstract):
                 )
             )
 
-        if destination.endpoint.startswith("*"):  # type: ignore
-            options += [
-                SuricataOption(name="dotprefix"),
-                SuricataOption(name="content", value=destination.endpoint[1:]),  # type: ignore
-                SuricataOption(name="nocase"),
-                SuricataOption(name="endswith"),
-            ]
-        else:
-            options += [
-                SuricataOption(name="content", value=destination.endpoint),
-                SuricataOption(name="nocase"),
-                SuricataOption(name="startswith"),
-                SuricataOption(name="endswith"),
-            ]
+        if destination.endpoint:
+            if destination.endpoint.startswith("*"):  # type: ignore
+                options += [
+                    SuricataOption(name="dotprefix"),
+                    SuricataOption(name="content", value=destination.endpoint[1:]),  # type: ignore
+                    SuricataOption(name="nocase"),
+                    SuricataOption(name="endswith"),
+                ]
+            else:
+                options += [
+                    SuricataOption(name="content", value=destination.endpoint),
+                    SuricataOption(name="nocase"),
+                    SuricataOption(name="startswith"),
+                    SuricataOption(name="endswith"),
+                ]
 
         return options
 

--- a/aws_network_firewall/engines/tls_rule.py
+++ b/aws_network_firewall/engines/tls_rule.py
@@ -38,9 +38,9 @@ class TlsRule(EngineAbstract):
             )
         ]
 
-    @staticmethod
+    @classmethod
     def __resolve_tls_options(
-        destination: Destination, ssl_version: Optional[str]
+        cls, destination: Destination, ssl_version: Optional[str]
     ) -> List[SuricataOption]:
         options = [
             SuricataOption(name="tls.sni"),
@@ -53,22 +53,26 @@ class TlsRule(EngineAbstract):
             )
 
         if destination.endpoint:
-            if destination.endpoint.startswith("*"):  # type: ignore
-                options += [
-                    SuricataOption(name="dotprefix"),
-                    SuricataOption(name="content", value=destination.endpoint[1:]),  # type: ignore
-                    SuricataOption(name="nocase"),
-                    SuricataOption(name="endswith"),
-                ]
-            else:
-                options += [
-                    SuricataOption(name="content", value=destination.endpoint),
-                    SuricataOption(name="nocase"),
-                    SuricataOption(name="startswith"),
-                    SuricataOption(name="endswith"),
-                ]
+            options += cls.__resolve_sni_options(destination.endpoint)
 
         return options
+
+    @staticmethod
+    def __resolve_sni_options(endpoint: str) -> List[SuricataOption]:
+        if endpoint.startswith("*"):
+            return [
+                SuricataOption(name="dotprefix"),
+                SuricataOption(name="content", value=endpoint[1:]),
+                SuricataOption(name="nocase"),
+                SuricataOption(name="endswith"),
+            ]
+
+        return [
+            SuricataOption(name="content", value=endpoint),
+            SuricataOption(name="nocase"),
+            SuricataOption(name="startswith"),
+            SuricataOption(name="endswith"),
+        ]
 
     def __resolve_tls_version_rules(
         self, destination: Destination

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -483,3 +483,30 @@ def test_no_sid_state() -> None:
         'pass tcp 10.0.0.10/32 any -> @S3PrefixList 443 (msg:"my-workload | my-rule"; sid:0; rev:1;)'
         == str(rule)
     )
+
+
+def test_tls_no_endpoint() -> None:
+    rule = Rule(
+        workload="my-workload",
+        name="my-rule",
+        region="eu-west-1",
+        type=Rule.INSPECTION,
+        description="My description",
+        sources=[Source(description="my source", cidr="10.0.0.10/32")],
+        destinations=[
+            Destination(
+                description="my destination",
+                protocol="TLS",
+                port=443,
+                endpoint=None,
+                cidr="192.168.0.1/32",
+                message="",
+                tls_versions=["tls1.2", "tls1.3"],
+            )
+        ],
+    )
+
+    assert (
+        'pass tls 10.0.0.10/32 any -> 192.168.0.1/32 443 (tls.sni; ssl_version:tls1.2,tls1.3; msg:"my-workload | my-rule"; sid:0; rev:1;)'
+        == str(rule)
+    )


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

In some cases you do not want to match on the `SNI` (Server Name Indicator). But you do want to enforce the usage of TLS on the connection. In these cases we should not try to add the SNI option in the suricata rule.

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
