### PR TITLE
fix: flow value should not be quoted

### DIFF
--- a/aws_network_firewall/engines/tls_rule.py
+++ b/aws_network_firewall/engines/tls_rule.py
@@ -109,7 +109,9 @@ class TlsRule(EngineAbstract):
                 address=destination.cidr if destination.cidr else "",
                 port=destination.port if destination.port else 0,
             ),
-            options=[SuricataOption(name="flow", value="not_established")]
+            options=[
+                SuricataOption(name="flow", value="not_established", quoted_value=False)
+            ]
             + self.resolve_options(destination),
         )
         rule.enable_bidirectional_communication()

--- a/tests/test_rule.py
+++ b/tests/test_rule.py
@@ -168,7 +168,7 @@ def test_rule_with_tls_endpoint_non_standard_port() -> None:
 
     assert (
         'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:100; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:101; rev:1;)'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:not_established; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:101; rev:1;)'
         == str(rule)
     )
 
@@ -197,7 +197,7 @@ def test_rule_with_tls_endpoint_non_standard_port_and_message() -> None:
 
     assert (
         'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; content:"xebia.com"; nocase; startswith; endswith; msg:"IMPORTANT | my-workload | my-rule"; sid:200; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"IMPORTANT | Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:not_established; msg:"IMPORTANT | Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -225,7 +225,7 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_2_version() -> None:
     rule.register_sid_state(SidState("200-205"))
     assert (
         'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:not_established; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -254,7 +254,7 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_3_version() -> None:
 
     assert (
         'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:not_established; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 
@@ -284,7 +284,7 @@ def test_rule_with_tls_endpoint_non_standard_port_and_tls_1_2_and_1_3_version() 
 
     assert (
         'pass tls 10.0.0.0/24 any -> 10.0.1.0/24 444 (tls.sni; ssl_version:tls1.2,tls1.3; content:"xebia.com"; nocase; startswith; endswith; msg:"my-workload | my-rule"; sid:200; rev:1;)\n'
-        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:"not_established"; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
+        + 'pass tcp 10.0.0.0/24 any <> 10.0.1.0/24 444 (flow:not_established; msg:"Pass non-established TCP for 3-way handshake | my-workload | my-rule"; sid:201; rev:1;)'
         == str(rule)
     )
 


### PR DESCRIPTION
**Issue #, if available:**

## Description of changes:

As pointed out by @KaspervdG the `flow` option should not be quoted. This PR is addressing that issue

**Checklist**

<!--- Leave unchecked if your change doesn't seem to apply -->

* [x] Update tests
* [ ] Update docs
* [x] PR title follows [conventional commit semantics](https://www.conventionalcommits.org/en/v1.0.0-beta.2/#commit-message-for-a-fix-using-an-optional-issue-number)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
